### PR TITLE
fix clippy lints

### DIFF
--- a/optional-fields-serde-macro/src/lib.rs
+++ b/optional-fields-serde-macro/src/lib.rs
@@ -28,8 +28,8 @@ fn add_serde_optional_fields(field: &mut Field) -> Result<(), String> {
     if let Type::Path(path) = &field.ty {
         if is_field(&path.path) {
             let has_skip_serializing_if =
-                field_has_attribute(&field, "serde", "skip_serializing_if");
-            let has_default = field_has_attribute(&field, "serde", "default");
+                field_has_attribute(field, "serde", "skip_serializing_if");
+            let has_default = field_has_attribute(field, "serde", "default");
 
             if !has_skip_serializing_if {
                 let attr_tokens = quote!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde")]
 pub use optional_fields_serde_macro::serde_optional_fields;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Field<T> {
     Missing,
     Present(Option<T>),


### PR DESCRIPTION
This is very minor, but clippy will complain about a couple of things:

* Eq can be derived
> you are deriving `PartialEq` and can implement `Eq`
> `#[warn(clippy::derive_partial_eq_without_eq)]` on by default
> for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

* A needless borrow in the proc macro
> this expression creates a reference which is immediately dereferenced by the compiler
> `#[warn(clippy::needless_borrow)]` on by default
> for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

It would be nice to have for users to be able to derive Eq on structs containing a Field.

I only really came to fix that, but then clippy showed me the second and I thought what the heck!

Thank you so much for the crate, I'm finding it very useful when deserializing enums with, well... optional fields! heh.